### PR TITLE
Improved help command to only show commands the user has access to

### DIFF
--- a/moebot_bot/bot/bot.go
+++ b/moebot_bot/bot/bot.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/camd67/moebot/moebot_bot/bot/commands"
+	"github.com/camd67/moebot/moebot_bot/bot/permissions"
 	"github.com/camd67/moebot/moebot_bot/util"
 	"github.com/camd67/moebot/moebot_bot/util/db"
 
@@ -22,7 +23,7 @@ var (
 	Config               = make(map[string]string)
 	operations           []interface{}
 	commandsMap          = make(map[string]commands.Command)
-	checker              PermissionChecker
+	checker              permissions.PermissionChecker
 	masterId             string
 )
 
@@ -31,7 +32,7 @@ func SetupMoebot(session *discordgo.Session) {
 	db.SetupDatabase(Config["dbPass"], Config["moeDataPass"])
 	addGlobalHandlers(session)
 	setupOperations(session)
-	checker = PermissionChecker{MasterId: masterId}
+	checker = permissions.PermissionChecker{MasterId: masterId}
 }
 
 func setupOperations(session *discordgo.Session) {
@@ -41,7 +42,7 @@ func setupOperations(session *discordgo.Session) {
 		&commands.RoleCommand{},
 		&commands.RankCommand{Handler: roleHandler},
 		&commands.NsfwCommand{Handler: roleHandler},
-		&commands.HelpCommand{ComPrefix: ComPrefix},
+		&commands.HelpCommand{ComPrefix: ComPrefix, CommandsMap: commandsMap, Checker: checker},
 		&commands.ChangelogCommand{Version: version},
 		&commands.RaffleCommand{MasterId: masterId, DebugChannel: Config["debugChannel"]},
 		&commands.SubmitCommand{ComPrefix: ComPrefix},

--- a/moebot_bot/bot/commands/changelog.go
+++ b/moebot_bot/bot/commands/changelog.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
@@ -67,4 +69,8 @@ func (cc *ChangelogCommand) GetPermLevel() db.Permission {
 
 func (cc *ChangelogCommand) GetCommandKeys() []string {
 	return []string{"CHANGELOG"}
+}
+
+func (c *ChangelogCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s changelog` - Displays the changelog for moebot", commPrefix)
 }

--- a/moebot_bot/bot/commands/commands.go
+++ b/moebot_bot/bot/commands/commands.go
@@ -18,6 +18,7 @@ type Command interface {
 	Execute(pack *CommPackage)
 	GetPermLevel() db.Permission
 	GetCommandKeys() []string
+	GetCommandHelp(commPrefix string) string
 }
 
 type EventHandler interface {

--- a/moebot_bot/bot/commands/custom.go
+++ b/moebot_bot/bot/commands/custom.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -67,4 +68,8 @@ func (cc *CustomCommand) GetPermLevel() db.Permission {
 
 func (cc *CustomCommand) GetCommandKeys() []string {
 	return []string{"CUSTOM"}
+}
+
+func (c *CustomCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s custom <command name> <role name>` - Master/All/Mod Links up a role to be toggable by the command name. Type `%[1]s role <command name> to toggle`", commPrefix)
 }

--- a/moebot_bot/bot/commands/echo.go
+++ b/moebot_bot/bot/commands/echo.go
@@ -26,3 +26,7 @@ func (ec *EchoCommand) GetPermLevel() db.Permission {
 func (ec *EchoCommand) GetCommandKeys() []string {
 	return []string{"ECHO"}
 }
+
+func (c *EchoCommand) GetCommandHelp(commPrefix string) string {
+	return ""
+}

--- a/moebot_bot/bot/commands/help.go
+++ b/moebot_bot/bot/commands/help.go
@@ -1,28 +1,27 @@
 package commands
 
 import (
+	"fmt"
+
+	"github.com/camd67/moebot/moebot_bot/bot/permissions"
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
 type HelpCommand struct {
-	ComPrefix string
+	ComPrefix   string
+	CommandsMap map[string]Command
+	Checker     permissions.PermissionChecker
 }
 
 func (hc *HelpCommand) Execute(pack *CommPackage) {
 	if len(pack.params) == 0 {
-		pack.session.ChannelMessageSend(pack.channel.ID, "Moebot has the following commands:\n"+
-			"`"+hc.ComPrefix+" team <team name>` - Changes your team to one of the approved teams. `"+hc.ComPrefix+" team` to list all teams\n"+
-			"`"+hc.ComPrefix+" rank <rank name>` - Changes your rank to one of the approved ranks. `"+hc.ComPrefix+" rank` to list all the ranks\n"+
-			"`"+hc.ComPrefix+" changelog` - Displays the changelog for moebot\n"+
-			"`"+hc.ComPrefix+" NSFW` - Gives you NSFW channel permissions\n"+
-			"`"+hc.ComPrefix+" permit <role name> [-permission <perm level>] [-securityAnswer <answer>] [-confirmationMessage <message>]` - Master/All only. Edits the selected role to grant permission or add a confirmation procedure.\n"+
-			"`"+hc.ComPrefix+" custom <command name> <role name>` - Master/All/Mod Links up a role to be toggable by the command name. Type `"+hc.ComPrefix+" role <command name> to toggle`\n"+
-			"`"+hc.ComPrefix+" poll -options <option 1, option 2, option 3, ...> -title <poll title>` - Master/All/Mod set up a poll with the given options. Type `"+hc.ComPrefix+" poll -close <poll id> to close`\n"+
-			"`"+hc.ComPrefix+" pinmove [-sendTo <#destChannel>] [-text] <#channel>` - Enables moving messages from the specified channel to the server's destination channel. The `-sendTo` option sets/changes the default destination channel. The `-text` option enables moving text on pin\n"+
-			"`"+hc.ComPrefix+" role <role name>` - Changes your role to one of the approved roles. `"+hc.ComPrefix+" role` to list all the roles\n"+
-			"`"+hc.ComPrefix+" server <config setting> <value>` - Master/Mod Changes a config setting on the server to a given value. `"+hc.ComPrefix+" server` to list configs.\n"+
-			"`"+hc.ComPrefix+" profile - Displays your server profile"+
-			"`"+hc.ComPrefix+" help` - Displays this message")
+		message := "Moebot has the following commands:\n"
+		for _, v := range hc.CommandsMap {
+			if hc.Checker.HasPermission(pack.message.Author.ID, pack.member.Roles, v.GetPermLevel()) && v.GetCommandHelp(hc.ComPrefix) != "" {
+				message += v.GetCommandHelp(hc.ComPrefix) + "\n"
+			}
+		}
+		pack.session.ChannelMessageSend(pack.channel.ID, message)
 	}
 }
 
@@ -32,4 +31,8 @@ func (hc *HelpCommand) GetPermLevel() db.Permission {
 
 func (hc *HelpCommand) GetCommandKeys() []string {
 	return []string{"HELP"}
+}
+
+func (c *HelpCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s help` - Displays this message", commPrefix)
 }

--- a/moebot_bot/bot/commands/nsfw.go
+++ b/moebot_bot/bot/commands/nsfw.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
@@ -19,4 +21,8 @@ func (nc *NsfwCommand) GetPermLevel() db.Permission {
 
 func (nc *NsfwCommand) GetCommandKeys() []string {
 	return []string{"NSFW"}
+}
+
+func (c *NsfwCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s NSFW` - Gives you NSFW channel permissions", commPrefix)
 }

--- a/moebot_bot/bot/commands/permit.go
+++ b/moebot_bot/bot/commands/permit.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/camd67/moebot/moebot_bot/util"
@@ -62,4 +63,8 @@ func (pc *PermitCommand) GetPermLevel() db.Permission {
 
 func (pc *PermitCommand) GetCommandKeys() []string {
 	return []string{"PERMIT"}
+}
+
+func (c *PermitCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s permit <role name> [-permission <perm level>] [-securityAnswer <answer>] [-confirmationMessage <message>]` - Master/All only. Edits the selected role to grant permission or add a confirmation procedure.", commPrefix)
 }

--- a/moebot_bot/bot/commands/ping.go
+++ b/moebot_bot/bot/commands/ping.go
@@ -23,3 +23,7 @@ func (pc *PingCommand) GetPermLevel() db.Permission {
 func (pc *PingCommand) GetCommandKeys() []string {
 	return []string{"PING"}
 }
+
+func (c *PingCommand) GetCommandHelp(commPrefix string) string {
+	return ""
+}

--- a/moebot_bot/bot/commands/pinmove.go
+++ b/moebot_bot/bot/commands/pinmove.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"mime"
 	"path/filepath"
@@ -295,4 +296,8 @@ func (pc *PinMoveCommand) GetPermLevel() db.Permission {
 
 func (pc *PinMoveCommand) GetCommandKeys() []string {
 	return []string{"PINMOVE"}
+}
+
+func (c *PinMoveCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s pinmove [-sendTo <#destChannel>] [-text] <#channel>` - Enables moving messages from the specified channel to the server's destination channel. The `-sendTo` option sets/changes the default destination channel. The `-text` option enables moving text on pin", commPrefix)
 }

--- a/moebot_bot/bot/commands/poll.go
+++ b/moebot_bot/bot/commands/poll.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/bwmarrin/discordgo"
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
@@ -31,4 +33,8 @@ func (pc *PollCommand) GetPermLevel() db.Permission {
 
 func (pc *PollCommand) GetCommandKeys() []string {
 	return []string{"POLL"}
+}
+
+func (c *PollCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s poll -options <option 1, option 2, option 3, ...> -title <poll title>` - Master/All/Mod set up a poll with the given options. Type `%[1]s poll -close <poll id> to close`", commPrefix)
 }

--- a/moebot_bot/bot/commands/profile.go
+++ b/moebot_bot/bot/commands/profile.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"database/sql"
+	"fmt"
 	"strconv"
 
 	"github.com/camd67/moebot/moebot_bot/util"
@@ -98,4 +99,8 @@ func (pc *ProfileCommand) GetPermLevel() db.Permission {
 
 func (pc *ProfileCommand) GetCommandKeys() []string {
 	return []string{"PROFILE"}
+}
+
+func (c *ProfileCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s profile` - Displays your server profile", commPrefix)
 }

--- a/moebot_bot/bot/commands/raffle.go
+++ b/moebot_bot/bot/commands/raffle.go
@@ -247,3 +247,7 @@ func (rc *RaffleCommand) GetPermLevel() db.Permission {
 func (rc *RaffleCommand) GetCommandKeys() []string {
 	return []string{"RAFFLE"}
 }
+
+func (c *RaffleCommand) GetCommandHelp(commPrefix string) string {
+	return ""
+}

--- a/moebot_bot/bot/commands/rank.go
+++ b/moebot_bot/bot/commands/rank.go
@@ -1,12 +1,15 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
-type RankCommand struct{
+type RankCommand struct {
 	Handler *RoleHandler
 }
+
 func (rc *RankCommand) Execute(pack *CommPackage) {
 	rc.Handler.processGuildRole([]string{"Red", "Blue"}, pack.session, pack.params, pack.channel, pack.guild, pack.message, true, "rank")
 }
@@ -17,4 +20,8 @@ func (rc *RankCommand) GetPermLevel() db.Permission {
 
 func (rc *RankCommand) GetCommandKeys() []string {
 	return []string{"RANK"}
+}
+
+func (c *RankCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s rank <rank name>` - Changes your rank to one of the approved ranks. `%[1]s rank` to list all the ranks", commPrefix)
 }

--- a/moebot_bot/bot/commands/role.go
+++ b/moebot_bot/bot/commands/role.go
@@ -93,3 +93,6 @@ func (rc *RoleCommand) GetCommandKeys() []string {
 	return []string{"ROLE"}
 }
 
+func (c *RoleCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s role <role name>` - Changes your role to one of the approved roles. `%[1]s role` to list all the roles", commPrefix)
+}

--- a/moebot_bot/bot/commands/server.go
+++ b/moebot_bot/bot/commands/server.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -87,4 +88,8 @@ func (sc *ServerCommand) GetPermLevel() db.Permission {
 
 func (sc *ServerCommand) GetCommandKeys() []string {
 	return []string{"SERVER"}
+}
+
+func (c *ServerCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s server <config setting> <value>` - Master/Mod Changes a config setting on the server to a given value. `%[1]s server` to list configs.", commPrefix)
 }

--- a/moebot_bot/bot/commands/spoiler.go
+++ b/moebot_bot/bot/commands/spoiler.go
@@ -44,3 +44,7 @@ func (sc *SpoilerCommand) GetPermLevel() db.Permission {
 func (sc *SpoilerCommand) GetCommandKeys() []string {
 	return []string{"SPOILER"}
 }
+
+func (c *SpoilerCommand) GetCommandHelp(commPrefix string) string {
+	return ""
+}

--- a/moebot_bot/bot/commands/submit.go
+++ b/moebot_bot/bot/commands/submit.go
@@ -75,3 +75,7 @@ func (sc *SubmitCommand) GetPermLevel() db.Permission {
 func (sc *SubmitCommand) GetCommandKeys() []string {
 	return []string{"SUBMIT"}
 }
+
+func (c *SubmitCommand) GetCommandHelp(commPrefix string) string {
+	return ""
+}

--- a/moebot_bot/bot/commands/team.go
+++ b/moebot_bot/bot/commands/team.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
@@ -18,4 +20,8 @@ func (tc *TeamCommand) GetPermLevel() db.Permission {
 
 func (sc *TeamCommand) GetCommandKeys() []string {
 	return []string{"TEAM"}
+}
+
+func (c *TeamCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s team <team name>` - Changes your team to one of the approved teams. `%[1]s team` to list all teams", commPrefix)
 }

--- a/moebot_bot/bot/commands/togglemention.go
+++ b/moebot_bot/bot/commands/togglemention.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -57,4 +58,8 @@ func (mc *MentionCommand) GetPermLevel() db.Permission {
 
 func (mc *MentionCommand) GetCommandKeys() []string {
 	return []string{"TOGGLEMENTION"}
+}
+
+func (c *MentionCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s togglemention <role name>` enables/disables mentioning the selected role for 5 minutes", commPrefix)
 }

--- a/moebot_bot/bot/permissions/permissionChecker.go
+++ b/moebot_bot/bot/permissions/permissionChecker.go
@@ -1,4 +1,4 @@
-package bot
+package permissions
 
 import (
 	"github.com/camd67/moebot/moebot_bot/util/db"


### PR DESCRIPTION
# This pull request changes the following things:

Improves the help command and checks permissions for every command before showing the help line

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [x] Run `go fmt` on all the files I've changed
- [x] Tested the bot on my own server to verify the feature works
- [x] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [x] Submitted PR to the develop branch _not master!_
