### PR TITLE
Fix 'server WelcomeChannel' incorrectly output the BotChannel

### DIFF
--- a/moebot_bot/bot/commands/server.go
+++ b/moebot_bot/bot/commands/server.go
@@ -111,7 +111,7 @@ func (sc *ServerCommand) processServerConfigKey(configKey string, configValue st
 		}
 	} else if configKey == "WELCOMECHANNEL" {
 		if isHelp {
-			pack.session.ChannelMessageSend(pack.channel.ID, "WelcomeChannel: "+util.GetStringOrDefault(s.BotChannel))
+			pack.session.ChannelMessageSend(pack.channel.ID, "WelcomeChannel: "+util.GetStringOrDefault(s.WelcomeChannel))
 		} else if shouldClear {
 			s.WelcomeChannel.Scan(nil)
 		} else {


### PR DESCRIPTION
# This pull request changes the following things:
Fixes https://github.com/camd67/moebot/issues/43

The `server WelcomeChannel` command was incorrectly output the value of the BotChannel config value. This was rectified to correctly output the WelcomeChannel config value.

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [x] Run `go fmt` on all the files I've changed
- [x] Tested the bot on my own server to verify the feature works
- [x] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [x] Submitted PR to the develop branch _not master!_
