### PR TITLE
fix for help command showing help for multiple aliases

### DIFF
--- a/moebot_bot/bot/bot.go
+++ b/moebot_bot/bot/bot.go
@@ -48,7 +48,7 @@ func setupOperations(session *discordgo.Session) {
 		&commands.RoleCommand{},
 		&commands.RoleSetCommand{ComPrefix: ComPrefix},
 		&commands.GroupSetCommand{ComPrefix: ComPrefix},
-		&commands.HelpCommand{ComPrefix: ComPrefix, CommandsMap: commandsMap, Checker: checker},
+		&commands.HelpCommand{ComPrefix: ComPrefix, Commands: getCommands, Checker: checker}, //using a delegate here because it will remain accurate regardless of what gets added to operations
 		&commands.ChangelogCommand{Version: version},
 		&commands.RaffleCommand{MasterId: masterId, DebugChannel: masterDebugChannel},
 		&commands.SubmitCommand{ComPrefix: ComPrefix},
@@ -69,15 +69,23 @@ func setupOperations(session *discordgo.Session) {
 	setupEvents(session)
 }
 
+func getCommands() []commands.Command {
+	result := []commands.Command{}
+	for _, o := range operations {
+		if command, ok := o.(commands.Command); ok {
+			result = append(result, command)
+		}
+	}
+	return result
+}
+
 /*
 Run through each operation and place each command into the command map (including any aliases)
 */
 func setupCommands() {
-	for _, o := range operations {
-		if command, ok := o.(commands.Command); ok {
-			for _, key := range command.GetCommandKeys() {
-				commandsMap[key] = command
-			}
+	for _, command := range getCommands() {
+		for _, key := range command.GetCommandKeys() {
+			commandsMap[key] = command
 		}
 	}
 }

--- a/moebot_bot/bot/commands/help.go
+++ b/moebot_bot/bot/commands/help.go
@@ -8,15 +8,15 @@ import (
 )
 
 type HelpCommand struct {
-	ComPrefix   string
-	CommandsMap map[string]Command
-	Checker     permissions.PermissionChecker
+	ComPrefix string
+	Commands  func() []Command
+	Checker   permissions.PermissionChecker
 }
 
 func (hc *HelpCommand) Execute(pack *CommPackage) {
 	if len(pack.params) == 0 {
 		message := "Moebot has the following commands:\n"
-		for _, v := range hc.CommandsMap {
+		for _, v := range hc.Commands() {
 			if hc.Checker.HasPermission(pack.message.Author.ID, pack.member.Roles, pack.guild, v.GetPermLevel()) && v.GetCommandHelp(hc.ComPrefix) != "" {
 				message += v.GetCommandHelp(hc.ComPrefix) + "\n"
 			}


### PR DESCRIPTION
# This pull request changes the following things:

Fixes help showing helptext for every alias of a command by iterating over a delegate returning commands from the operations list.

Fixes https://github.com/camd67/moebot/issues/45

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [x] Run `go fmt` on all the files I've changed
- [x] Tested the bot on my own server to verify the feature works
- [x] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [x] Submitted PR to the develop branch _not master!_
