### PR TITLE
Fix updating an existing user's rank not returning the updated values

### DIFF
--- a/moebot_bot/util/db/userServerRank.go
+++ b/moebot_bot/util/db/userServerRank.go
@@ -71,6 +71,7 @@ func UserServerRankUpdateOrInsert(userId int, serverId int, points int) (id int,
 			log.Println("Error updating userServerRank", err)
 			return
 		}
+		return
 	}
 	return u.Id, u.Rank, u.MessageSent, nil
 }


### PR DESCRIPTION
# This pull request changes the following things:

Fixes issue where moebot wouldn't immediately announce when users could become veteran. The correct `Rank` and `MessageSent` values weren't being return by `UserServerRankUpdateOrInsert` if the user had an existing record in the `user_server_rank` table (which would probably happen always unless the Veteran Rank for the server could be reached before the points buffer filled once.)

Fixes #48 

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [x] Run `go fmt` on all the files I've changed
- [x] Tested the bot on my own server to verify the feature works
- [x] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [x] Submitted PR to the develop branch _not master!_
