### PR TITLE
Added timer command

### DIFF
--- a/moebot_bot/bot/bot.go
+++ b/moebot_bot/bot/bot.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/camd67/moebot/moebot_bot/bot/commands"
 	"github.com/camd67/moebot/moebot_bot/bot/permissions"
@@ -69,7 +68,7 @@ func setupOperations(session *discordgo.Session, redditHandle *reddit.Handle) {
 		&commands.ProfileCommand{MasterId: masterId},
 		&commands.PinMoveCommand{},
 		&commands.SubCommand{RedditHandle: redditHandle},
-		&commands.TimerCommand{StartTime: time.Now()},
+		&commands.TimerCommand{},
 		commands.NewVeteranHandler(ComPrefix, masterDebugChannel, masterId),
 	}
 

--- a/moebot_bot/bot/bot.go
+++ b/moebot_bot/bot/bot.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/camd67/moebot/moebot_bot/bot/commands"
 	"github.com/camd67/moebot/moebot_bot/bot/permissions"
@@ -68,6 +69,7 @@ func setupOperations(session *discordgo.Session, redditHandle *reddit.Handle) {
 		&commands.ProfileCommand{MasterId: masterId},
 		&commands.PinMoveCommand{},
 		&commands.SubCommand{RedditHandle: redditHandle},
+		&commands.TimerCommand{StartTime: time.Now()},
 		commands.NewVeteranHandler(ComPrefix, masterDebugChannel, masterId),
 	}
 

--- a/moebot_bot/bot/bot.go
+++ b/moebot_bot/bot/bot.go
@@ -68,7 +68,7 @@ func setupOperations(session *discordgo.Session, redditHandle *reddit.Handle) {
 		&commands.ProfileCommand{MasterId: masterId},
 		&commands.PinMoveCommand{},
 		&commands.SubCommand{RedditHandle: redditHandle},
-		&commands.TimerCommand{},
+		commands.NewTimerCommand(),
 		commands.NewVeteranHandler(ComPrefix, masterDebugChannel, masterId),
 	}
 

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -12,6 +12,12 @@ type TimerCommand struct {
 	chTimers map[string]time.Time
 }
 
+func NewTimerCommand() *TimerCommand {
+	tc := &TimerCommand{}
+	tc.chTimers = map[string]time.Time{}
+	return tc
+}
+
 func (tc *TimerCommand) Execute(pack *CommPackage) {
 	channelID := pack.message.ChannelID
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -5,11 +5,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/camd67/moebot/moebot_bot/bot/permissions"
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
 type TimerCommand struct {
 	chTimers map[string]time.Time
+	Checker  permissions.PermissionChecker
 }
 
 func NewTimerCommand() *TimerCommand {
@@ -21,8 +23,12 @@ func NewTimerCommand() *TimerCommand {
 func (tc *TimerCommand) Execute(pack *CommPackage) {
 	channelID := pack.message.ChannelID
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
-		tc.chTimers[channelID] = time.Now()
-		pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started OwO")
+		if tc.Checker.HasPermission(pack.message.Author.ID, pack.member.Roles, pack.guild, db.PermMod) {
+			tc.chTimers[channelID] = time.Now()
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started OwO")
+		} else {
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "You... you don't have permission to do that! ( ≧Д≦)")
+		}
 	} else {
 		if v, ok := tc.chTimers[channelID]; ok {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(v)))

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/camd67/moebot/moebot_bot/util/db"
@@ -12,7 +13,12 @@ type TimerCommand struct {
 }
 
 func (tc *TimerCommand) Execute(pack *CommPackage) {
-	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(tc.StartTime)))
+	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
+		tc.StartTime = time.Now()
+		pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started")
+	} else {
+		pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(tc.StartTime)))
+	}
 }
 
 func fmtDuration(dur time.Duration) string {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -32,16 +32,16 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 			tc.chTimers.Lock()
 			tc.chTimers.M[channelID] = time.Now()
 			tc.chTimers.Unlock()
-			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started! OwO")
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started!")
 		} else {
-			pack.session.ChannelMessageSend(pack.message.ChannelID, pack.message.Author.Mention()+", you... you don't have permission to do that! ( ≧Д≦)")
+			pack.session.ChannelMessageSend(pack.message.ChannelID, pack.message.Author.Mention()+", you... you don't have permission to do that!")
 		}
 	} else {
 		tc.chTimers.Lock()
 		if v, ok := tc.chTimers.M[channelID]; ok {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(v)))
 		} else {
-			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel... -w-")
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel...")
 		}
 		tc.chTimers.Unlock()
 	}

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -3,14 +3,13 @@ package commands
 import (
 	"fmt"
 
-	"github.com/camd67/moebot/moebot_bot/bot/permissions"
-
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
 type TimerCommand struct {
-	ComPrefix string
-	Checker   permissions.PermissionChecker
+}
+
+func (tc *TimerCommand) Execute(pack *CommPackage) {
 }
 
 func (tc *TimerCommand) GetPermLevel() db.Permission {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -2,14 +2,17 @@ package commands
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
 type TimerCommand struct {
+	StartTime time.Time
 }
 
 func (tc *TimerCommand) Execute(pack *CommPackage) {
+	pack.session.ChannelMessageSend(pack.message.ChannelID, time.Since(tc.StartTime).Round(time.Second).String())
 }
 
 func (tc *TimerCommand) GetPermLevel() db.Permission {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -3,20 +3,25 @@ package commands
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/camd67/moebot/moebot_bot/bot/permissions"
+	"github.com/camd67/moebot/moebot_bot/util"
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
 type TimerCommand struct {
-	chTimers map[string]time.Time
+	chTimers util.SyncChannelTimerMap
 	Checker  permissions.PermissionChecker
 }
 
 func NewTimerCommand() *TimerCommand {
 	tc := &TimerCommand{}
-	tc.chTimers = map[string]time.Time{}
+	tc.chTimers = util.SyncChannelTimerMap{
+		RWMutex: sync.RWMutex{},
+		M:       make(map[string]time.Time),
+	}
 	return tc
 }
 
@@ -24,20 +29,25 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 	channelID := pack.message.ChannelID
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
 		if tc.Checker.HasPermission(pack.message.Author.ID, pack.member.Roles, pack.guild, db.PermMod) {
-			tc.chTimers[channelID] = time.Now()
+			tc.chTimers.Lock()
+			tc.chTimers.M[channelID] = time.Now()
+			tc.chTimers.Unlock()
 			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started! OwO")
 		} else {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, pack.message.Author.Mention()+", you... you don't have permission to do that! ( ≧Д≦)")
 		}
 	} else {
-		if v, ok := tc.chTimers[channelID]; ok {
+		tc.chTimers.Lock()
+		if v, ok := tc.chTimers.M[channelID]; ok {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(v)))
 		} else {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel... -w-")
 		}
+		tc.chTimers.Unlock()
 	}
 }
 
+// fmtDuration formats a duration into a hh:mm:ss format
 func fmtDuration(dur time.Duration) string {
 	remainingDur := dur.Round(time.Second)
 	hours := remainingDur / time.Hour

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -12,7 +12,17 @@ type TimerCommand struct {
 }
 
 func (tc *TimerCommand) Execute(pack *CommPackage) {
-	pack.session.ChannelMessageSend(pack.message.ChannelID, time.Since(tc.StartTime).Round(time.Second).String())
+	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(tc.StartTime)))
+}
+
+func fmtDuration(dur time.Duration) string {
+	remainingDur := dur.Round(time.Second)
+	hours := remainingDur / time.Hour
+	remainingDur -= hours * time.Hour
+	minutes := remainingDur / time.Minute
+	remainingDur -= minutes * time.Minute
+	seconds := remainingDur / time.Second
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
 }
 
 func (tc *TimerCommand) GetPermLevel() db.Permission {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -9,15 +9,20 @@ import (
 )
 
 type TimerCommand struct {
-	StartTime time.Time
+	chTimers map[string]time.Time
 }
 
 func (tc *TimerCommand) Execute(pack *CommPackage) {
+	channelID := pack.message.ChannelID
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
-		tc.StartTime = time.Now()
+		tc.chTimers[channelID] = time.Now()
 		pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started OwO")
 	} else {
-		pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(tc.StartTime)))
+		if v, ok := tc.chTimers[channelID]; ok {
+			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(v)))
+		} else {
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel -w-")
+		}
 	}
 }
 

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -25,15 +25,15 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
 		if tc.Checker.HasPermission(pack.message.Author.ID, pack.member.Roles, pack.guild, db.PermMod) {
 			tc.chTimers[channelID] = time.Now()
-			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started OwO")
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started! OwO")
 		} else {
-			pack.session.ChannelMessageSend(pack.message.ChannelID, "You... you don't have permission to do that! ( ≧Д≦)")
+			pack.session.ChannelMessageSend(pack.message.ChannelID, pack.message.Author.Mention()+", you... you don't have permission to do that! ( ≧Д≦)")
 		}
 	} else {
 		if v, ok := tc.chTimers[channelID]; ok {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(v)))
 		} else {
-			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel -w-")
+			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel... -w-")
 		}
 	}
 }

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/camd67/moebot/moebot_bot/bot/permissions"
+
+	"github.com/camd67/moebot/moebot_bot/util/db"
+)
+
+type TimerCommand struct {
+	ComPrefix string
+	Checker   permissions.PermissionChecker
+}
+
+func (tc *TimerCommand) GetPermLevel() db.Permission {
+	return db.PermAll
+}
+
+func (tc *TimerCommand) GetCommandKeys() []string {
+	return []string{"TIMER"}
+}
+
+func (tc *TimerCommand) GetCommandHelp(commPrefix string) string {
+	return fmt.Sprintf("`%[1]s timer` - Checks the timestamp. Moderators may provide the `--start` option to begin start or restart the timer.", commPrefix)
+}

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -37,13 +37,13 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, pack.message.Author.Mention()+", you... you don't have permission to do that!")
 		}
 	} else {
-		tc.chTimers.Lock()
+		tc.chTimers.RLock()
 		if v, ok := tc.chTimers.M[channelID]; ok {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(v)))
 		} else {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel...")
 		}
-		tc.chTimers.Unlock()
+		tc.chTimers.RUnlock()
 	}
 }
 

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -15,7 +15,7 @@ type TimerCommand struct {
 func (tc *TimerCommand) Execute(pack *CommPackage) {
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
 		tc.StartTime = time.Now()
-		pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started")
+		pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started OwO")
 	} else {
 		pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(tc.StartTime)))
 	}

--- a/moebot_bot/util/util.go
+++ b/moebot_bot/util/util.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -28,6 +29,11 @@ type SyncUIDByChannelMap struct {
 type SyncCooldownMap struct {
 	sync.RWMutex
 	M map[string]int64
+}
+
+type SyncChannelTimerMap struct {
+	sync.RWMutex
+	M map[string]time.Time
 }
 
 func IntContains(s []int, e int) bool {


### PR DESCRIPTION
# This pull request changes the following things:

Added a timer command for synchronizing time between users. Moderators can start (or restart) timers with `timer start`. All users can get the current timestamp with `timer`. Timers are unique by each channel.

I went with your implementation storing the timestamps for each channel, specifically stored in a map.

Let me know if you think steps for concurrency are warranted here. I didn't bother with it since I couldn't imagine a situation where a race condition would cause an issue.

Implements #52 

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [x] Run `go fmt` on all the files I've changed
- [x] Tested the bot on my own server to verify the feature works
- [x] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [x] Submitted PR to the develop branch _not master!_
