### PR TITLE
Update timer command to write out

### DIFF
--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -133,7 +133,7 @@ func (tc *TimerCommand) GetCommandKeys() []string {
 }
 
 func (tc *TimerCommand) GetCommandHelp(commPrefix string) string {
-	return fmt.Sprintf("`%[1]s timer` - Checks the timestamp. Moderators may provide the `--start` option to begin start or restart the timer.", commPrefix)
+	return fmt.Sprintf("`%[1]s timer` - Checks the timer. Moderators may provide the `start` option to start (or restart) the timer.", commPrefix)
 }
 
 type SyncChannelTimerMap struct {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -16,15 +16,15 @@ const (
 )
 
 type TimerCommand struct {
-	chTimers SyncChannelTimerMap
+	chTimers syncChannelTimerMap
 	Checker  permissions.PermissionChecker
 }
 
 func NewTimerCommand() *TimerCommand {
 	tc := &TimerCommand{}
-	tc.chTimers = SyncChannelTimerMap{
+	tc.chTimers = syncChannelTimerMap{
 		RWMutex: sync.RWMutex{},
-		M:       make(map[string]*ChannelTimer),
+		M:       make(map[string]*channelTimer),
 	}
 	return tc
 }
@@ -46,7 +46,7 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 			}
 
 			// Create a new timer
-			tc.chTimers.M[channelID] = &ChannelTimer{
+			tc.chTimers.M[channelID] = &channelTimer{
 				time:      time.Now(),
 				writes:    0,
 				isWriting: false,
@@ -78,7 +78,7 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 	}
 }
 
-func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
+func (ct *channelTimer) writeTimes(pack *CommPackage) {
 	duration := time.Since(ct.time)
 
 	// Write the time once right away
@@ -156,12 +156,12 @@ func (tc *TimerCommand) GetCommandHelp(commPrefix string) string {
 	return fmt.Sprintf("`%[1]s timer` - Checks the timer. Moderators may provide the `start` option to start (or restart) the timer.", commPrefix)
 }
 
-type SyncChannelTimerMap struct {
+type syncChannelTimerMap struct {
 	sync.RWMutex
-	M map[string]*ChannelTimer
+	M map[string]*channelTimer
 }
 
-type ChannelTimer struct {
+type channelTimer struct {
 	sync.Mutex
 	time      time.Time
 	writes    int

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -110,6 +110,9 @@ func (ct *channelTimer) writeTimes(pack *CommPackage) {
 		case msg, chOpen := <-ct.requestCh:
 			// Break out of this loop if the channel was closed or a "stop" was issued
 			if !chOpen || msg == "stop" {
+				ct.Lock()
+				ct.isWriting = false
+				ct.Unlock()
 				return
 			}
 

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -85,13 +85,12 @@ func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
 	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
 	ct.writes = 1
 
-TimerWriting:
 	for {
 		select {
 		case msg, chOpen := <-ct.requestCh:
 			// Break out of this loop if the channel was closed (probably shouldn't be closed since there are multiple writeres) or a "stop" was issued
 			if !chOpen || msg == "stop" {
-				break TimerWriting
+				return
 			}
 
 		case <-time.After(time.Second * writeInterval):
@@ -107,7 +106,7 @@ TimerWriting:
 			if ct.writes >= maxWrites {
 				ct.isWriting = false
 				ct.Unlock()
-				break TimerWriting
+				return
 			}
 			ct.Unlock()
 		}

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -50,15 +50,13 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 func (tc *TimerCommand) writeTimesToChannel(pack *CommPackage, startTime time.Time) {
 	//Write the time once right away
 	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(startTime)))
-
-	addedSeconds := 0
+	duration := time.Since(startTime)
 	for {
 		select {
 		case <-time.After(time.Second * 1):
 			// Increment the duration by one second, post the time
-			addedSeconds++
-			// pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(startTime.Add(time.Second*time.Duration(addedSeconds)))))
-			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(startTime)+time.Duration(addedSeconds)))
+			duration += time.Duration(1 * time.Second)
+			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
 		}
 	}
 }

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -79,7 +80,7 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 }
 
 func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
-	duration := time.Since(ct.time).Truncate(time.Second)
+	duration := time.Since(ct.time)
 
 	// Write the time once right away
 	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
@@ -92,6 +93,7 @@ func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
 		timeUntilSync := writeInterval - (duration % writeInterval)
 		time.Sleep(timeUntilSync)
 		duration += timeUntilSync
+		log.Println(duration)
 		pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
 		ct.Lock()
 		ct.writes++

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -108,7 +108,7 @@ func (ct *channelTimer) writeTimes(pack *CommPackage) {
 	for {
 		select {
 		case msg, chOpen := <-ct.requestCh:
-			// Break out of this loop if the channel was closed (probably shouldn't be closed since there are multiple writeres) or a "stop" was issued
+			// Break out of this loop if the channel was closed or a "stop" was issued
 			if !chOpen || msg == "stop" {
 				return
 			}

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -107,9 +107,9 @@ func (ct *channelTimer) writeTimes(pack *CommPackage) {
 	// Start writing until we reach the max number of writes or get a message to stop
 	for {
 		select {
-		case msg, chOpen := <-ct.requestCh:
-			// Break out of this loop if the channel was closed or a "stop" was issued
-			if !chOpen || msg == "stop" {
+		case _, chOpen := <-ct.requestCh:
+			// Break out of this loop if the channel was closed
+			if !chOpen {
 				ct.Lock()
 				ct.isWriting = false
 				ct.Unlock()

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -81,7 +80,6 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 
 func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
 	duration := time.Since(ct.time)
-	log.Println(duration)
 
 	// Write the time once right away
 	go func() {
@@ -95,7 +93,6 @@ func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
 	timeToSync := writeInterval - (duration % writeInterval)
 	time.Sleep(timeToSync)
 	duration += timeToSync
-	log.Println(duration)
 
 	// Write again if we spent a sufficient time syncing, otherwise just wait until the next write interval
 	go func() {

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -56,7 +56,9 @@ func (tc *TimerCommand) writeTimesToChannel(pack *CommPackage, startTime time.Ti
 		case <-time.After(time.Second * 1):
 			// Increment the duration by one second, post the time
 			duration += time.Duration(1 * time.Second)
-			pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
+			go func() {
+				pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(time.Since(startTime))+" vs. "+fmtDuration(duration))
+			}()
 		}
 	}
 }

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -118,7 +118,7 @@ func (ct *channelTimer) writeTimes(pack *CommPackage) {
 
 		case <-time.After(writeInterval):
 			// Increment the duration and write time to the channel
-			duration += (writeInterval)
+			duration += writeInterval
 			go func() {
 				pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
 			}()

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -7,24 +7,24 @@ import (
 	"time"
 
 	"github.com/camd67/moebot/moebot_bot/bot/permissions"
-	"github.com/camd67/moebot/moebot_bot/util"
 	"github.com/camd67/moebot/moebot_bot/util/db"
 )
 
 const (
-	maxWrites = 5 // Number of times to write out the time
+	maxWrites     = 4 // Number of times to write out the time
+	writeInterval = 5 // Number of seconds between each write
 )
 
 type TimerCommand struct {
-	chTimers util.SyncChannelTimerMap
+	chTimers SyncChannelTimerMap
 	Checker  permissions.PermissionChecker
 }
 
 func NewTimerCommand() *TimerCommand {
 	tc := &TimerCommand{}
-	tc.chTimers = util.SyncChannelTimerMap{
+	tc.chTimers = SyncChannelTimerMap{
 		RWMutex: sync.RWMutex{},
-		M:       make(map[string]time.Time),
+		M:       make(map[string]*ChannelTimer),
 	}
 	return tc
 }
@@ -32,9 +32,27 @@ func NewTimerCommand() *TimerCommand {
 func (tc *TimerCommand) Execute(pack *CommPackage) {
 	channelID := pack.message.ChannelID
 	if len(pack.params) > 0 && strings.EqualFold(pack.params[0], "start") {
+		// Make sure the user has at least mod-level permissions before starting the timer
 		if tc.Checker.HasPermission(pack.message.Author.ID, pack.member.Roles, pack.guild, db.PermMod) {
 			tc.chTimers.Lock()
-			tc.chTimers.M[channelID] = time.Now()
+
+			// If this channel timer is currently writing out, tell it to stop
+			if chTimer, ok := tc.chTimers.M[channelID]; ok {
+				chTimer.Lock()
+				if chTimer.isWriting {
+					close(chTimer.requestCh)
+				}
+				chTimer.Unlock()
+			}
+
+			// Create a new timer
+			tc.chTimers.M[channelID] = &ChannelTimer{
+				time:      time.Now(),
+				writes:    0,
+				isWriting: false,
+				requestCh: make(chan string, 10),
+			}
+
 			tc.chTimers.Unlock()
 			pack.session.ChannelMessageSend(pack.message.ChannelID, "Timer started!")
 		} else {
@@ -42,8 +60,17 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 		}
 	} else {
 		tc.chTimers.RLock()
-		if v, ok := tc.chTimers.M[channelID]; ok {
-			go tc.writeTimesToChannel(pack, time.Since(v))
+		if chTimer, ok := tc.chTimers.M[channelID]; ok {
+			chTimer.Lock()
+			// Reset the number of writes
+			chTimer.writes = 0
+
+			// If the time is not writing, start it
+			if !chTimer.isWriting {
+				go chTimer.writeTimes(pack)
+				chTimer.isWriting = true
+			}
+			chTimer.Unlock()
 		} else {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel...")
 		}
@@ -51,24 +78,38 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 	}
 }
 
-func (tc *TimerCommand) writeTimesToChannel(pack *CommPackage, startDuration time.Duration) {
-	//Write the time once right away
-	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(startDuration))
-	duration := startDuration
-	writes := 1
+func (ct *ChannelTimer) writeTimes(pack *CommPackage) {
+	duration := time.Since(ct.time)
+
+	// Write the time once right away
+	pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
+	ct.writes = 1
+
+TimerWriting:
 	for {
 		select {
-		case <-time.After(time.Second * 1):
-			duration += time.Duration(time.Second)
+		case msg, chOpen := <-ct.requestCh:
+			// Break out of this loop if the channel was closed (probably shouldn't be closed since there are multiple writeres) or a "stop" was issued
+			if !chOpen || msg == "stop" {
+				break TimerWriting
+			}
+
+		case <-time.After(time.Second * writeInterval):
+			// Increment the duration and write time to the channel
+			duration += (time.Second * time.Duration(writeInterval))
 			go func() {
 				pack.session.ChannelMessageSend(pack.message.ChannelID, fmtDuration(duration))
 			}()
 
 			// Exit once we've reached the max write count
-			writes++
-			if writes >= maxWrites {
-				return
+			ct.Lock()
+			ct.writes++
+			if ct.writes >= maxWrites {
+				ct.isWriting = false
+				ct.Unlock()
+				break TimerWriting
 			}
+			ct.Unlock()
 		}
 	}
 }
@@ -94,4 +135,17 @@ func (tc *TimerCommand) GetCommandKeys() []string {
 
 func (tc *TimerCommand) GetCommandHelp(commPrefix string) string {
 	return fmt.Sprintf("`%[1]s timer` - Checks the timestamp. Moderators may provide the `--start` option to begin start or restart the timer.", commPrefix)
+}
+
+type SyncChannelTimerMap struct {
+	sync.RWMutex
+	M map[string]*ChannelTimer
+}
+
+type ChannelTimer struct {
+	sync.Mutex
+	time      time.Time
+	writes    int
+	isWriting bool
+	requestCh chan string
 }

--- a/moebot_bot/util/util.go
+++ b/moebot_bot/util/util.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 const (
@@ -29,11 +28,6 @@ type SyncUIDByChannelMap struct {
 type SyncCooldownMap struct {
 	sync.RWMutex
 	M map[string]int64
-}
-
-type SyncChannelTimerMap struct {
-	sync.RWMutex
-	M map[string]time.Time
 }
 
 func IntContains(s []int, e int) bool {


### PR DESCRIPTION
# This pull request changes the following things:

This pull request updates the timer command to write out a sequence of times, up from only being a one-time write.

The issue I'm seeing during testing is written times lag behind the time request anywhere from 0.5 seconds to 2 seconds. I suspect this is a combination of delay between the user typing `.moe timer start` and moebot receiving the command, and the delay between the user typing  `.moe timer` and moebot receiving the timer command.

Implements #54 

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [X] Run `go fmt` on all the files I've changed
- [X] Tested the bot on my own server to verify the feature works
- [X] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [X] Submitted PR to the develop branch _not master!_
