### PR TITLE
Extended timer alternative

### DIFF
--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -96,7 +96,8 @@ func writeTimes(pack *CommPackage, startTime time.Time, reqCh <-chan string) {
 	}()
 	writes++
 
-	// Synchronize the writes to be divisible by the interval (works well when interval is 5 so we get writes at times like 0:30, 0:35, 0:40, etc.)
+	// Synchronize the writes to be divisible by the interval
+	// (works well when interval is 5 so we get writes at times like 0:30, 0:35, 0:40, etc.)
 	timeToSync := writeInterval - (duration % writeInterval)
 	time.Sleep(timeToSync)
 	duration += timeToSync

--- a/moebot_bot/bot/commands/timer.go
+++ b/moebot_bot/bot/commands/timer.go
@@ -23,8 +23,8 @@ type TimerCommand struct {
 func NewTimerCommand() *TimerCommand {
 	tc := &TimerCommand{}
 	tc.chTimers = syncChannelTimerMap{
-		RWMutex: sync.RWMutex{},
-		M:       make(map[string]*channelTimer),
+		Mutex: sync.Mutex{},
+		M:     make(map[string]*channelTimer),
 	}
 	return tc
 }
@@ -56,7 +56,7 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, pack.message.Author.Mention()+", you... you don't have permission to do that!")
 		}
 	} else {
-		tc.chTimers.RLock()
+		tc.chTimers.Lock()
 		if chTimer, ok := tc.chTimers.M[channelID]; ok {
 			// Close existing writer, then start a new one
 			if chTimer.requestCh != nil {
@@ -67,7 +67,7 @@ func (tc *TimerCommand) Execute(pack *CommPackage) {
 		} else {
 			pack.session.ChannelMessageSend(pack.message.ChannelID, "No timer started for this channel...")
 		}
-		tc.chTimers.RUnlock()
+		tc.chTimers.Unlock()
 	}
 }
 
@@ -143,7 +143,7 @@ func (tc *TimerCommand) GetCommandHelp(commPrefix string) string {
 }
 
 type syncChannelTimerMap struct {
-	sync.RWMutex
+	sync.Mutex
 	M map[string]*channelTimer
 }
 


### PR DESCRIPTION
# This pull request changes the following things:

Alternative implementation of the timer in a more "go-like" manner. Should be easier to maintain. Also fixes the issue of "after-sync" writes occurring even if the writer has been stopped due to the `timer stop` or `timer start` commands.

## By submitting this Pull Request I agree to have done the following (check all that apply):

- [X] Run `go fmt` on all the files I've changed
- [X] Tested the bot on my own server to verify the feature works
- [X] Verified with CamD67 that the feature is desired (Check out the Projects page, or submit an issue for new features)
- [X] Submitted PR to the develop branch _not master!_
